### PR TITLE
Fix GM PID tuning code bug

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -126,7 +126,6 @@ class CarInterface(CarInterfaceBase):
       ret.steerRatio = 15.7
       ret.steerRatioRear = 0.
       ret.centerToFront = ret.wheelbase * 0.4 # wild guess
-      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.12], [0.05]]
       ret.steerRateCost = 0.7
 
@@ -196,11 +195,6 @@ class CarInterface(CarInterfaceBase):
     # mass and CG position, so all cars will have approximately similar dyn behaviors
     ret.tireStiffnessFront, ret.tireStiffnessRear = scale_tire_stiffness(ret.mass, ret.wheelbase, ret.centerToFront,
                                                                          tire_stiffness_factor=tire_stiffness_factor)
-
-    # same tuning for Volt and CT6 for now
-    ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0.], [0.]]
-    ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2], [0.00]]
-    ret.lateralTuning.pid.kf = 0.00004   # full torque for 20 deg at 80mph means 0.00007818594
 
     ret.steerMaxBP = [0.]  # m/s
     ret.steerMaxV = [1.]


### PR DESCRIPTION
Fixes a typo in PID tuning code. Repeated code block overrides any PID params set for individual models.

Error was caused by:
```
2e19e3c3f743229ea526ac87813c9782a1a38edb
2e19e3c3 kegman <8837066+kegman@users.noreply.github.com> on 10/29/19 at 10:26 AM
```

Incidentally, where does `kp = 0.12, kf=0.05` tuning for Volt come from? It was also added in the same commit when Pilot tuning was updated. @kegman. If this was erroneous, we should probably return it to defaults.