### PR TITLE
GM fix 'Controls Failed' on resuming after cycling main cruise switch

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -19,6 +19,7 @@ struct CarEvent @0x9b1657f34caf3ad3 {
   immediateDisable @6 :Bool;
   preEnable @7 :Bool;
   permanent @8 :Bool;
+  resetVCruise @9 :Bool;
 
   enum EventName @0xbaa8c5d505f727de {
     # TODO: copy from error list

--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -365,11 +365,18 @@ class CarInterface(CarInterfaceBase):
       # handle button presses
       for b in ret.buttonEvents:
         # do enable on both accel and decel buttons
-        if b.type in [ButtonType.accelCruise, ButtonType.decelCruise] and not b.pressed:
+        # The ECM will fault if resume triggers an enable while speed is set to 0
+        if b.type == ButtonType.accelCruise and c.hudControl.setSpeed > 0 and c.hudControl.setSpeed < 70 and not b.pressed:
+          events.append(create_event('buttonEnable', [ET.ENABLE]))
+        if b.type == ButtonType.decelCruise and not b.pressed:
           events.append(create_event('buttonEnable', [ET.ENABLE]))
         # do disable on button down
         if b.type == ButtonType.cancel and b.pressed:
           events.append(create_event('buttonCancel', [ET.USER_DISABLE]))
+        # The ECM independently tracks a ‘speed is set’ state that is reset on main off.
+        # To keep controlsd in sync with the ECM state, generate a RESET_V_CRUISE event on main cruise presses.
+        if b.type == ButtonType.altButton3 and b.pressed:
+          events.append(create_event('buttonCancel', [ET.RESET_V_CRUISE, ET.USER_DISABLE]))
 
     ret.events = events
 

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -144,6 +144,10 @@ def state_transition(frame, CS, CP, state, events, soft_disable_timer, v_cruise_
   # decrease the soft disable timer at every step, as it's reset on
   # entrance in SOFT_DISABLING state
   soft_disable_timer = max(0, soft_disable_timer - 1)
+  
+  # Reset v_cruise_kph to 0
+  if get_events(events, [ET.RESET_V_CRUISE]):
+    v_cruise_kph = 0
 
   # DISABLED
   if state == State.disabled:

--- a/selfdrive/controls/lib/drive_helpers.py
+++ b/selfdrive/controls/lib/drive_helpers.py
@@ -32,6 +32,7 @@ class EventTypes:
   SOFT_DISABLE = 'softDisable'
   IMMEDIATE_DISABLE = 'immediateDisable'
   PERMANENT = 'permanent'
+  RESET_V_CRUISE = 'resetVCruise'
 
 
 def create_event(name, types):


### PR DESCRIPTION
Originally by andrewcopenpilot.

The GM ECM independently tracks two cruise states, 'main on' and 'speed is set'.
Both must be true when resuming or the ECM generates a cruise fault. If
the ECM is driven to the main off state by the main cruise switch,
the set speed state is reset to false.

The OEM GM flow is if main cruise is cycled, the ASCM resets its speed
to 0, and the ECM goes into the no set speed state. 'Resume' presses will be
ignored (as the ASCM has a resume speed of 0). The 'Set' Button must be
pressed while meeting the minimum speed requirements to drive the ECM
and ASCM into the correct states to allow for ACC to operate.

Currently in OP controlsd remembers previously set speeds when cycling
the main cruise switch. This causes controlsd and the GM ECM's
respective state machines to get out of sync.

For example if we have a set speed of 55 mph, we press main cruise button once,
controlsd goes into a disabled state, the GM ECM goes into the 'main
off' and 'no speed set' state. We press the main cruise button a second time,
controlsd goes into the enabled state with the remembered speed of 55
mph, while the GM ECM goes into a 'main on' and 'no speed set' state. The UI
presents the user with the controlsd remembered 55 mph, so it is logical to
press 'Resume' if that is desired, however due to the GM ECM still being
in the 'no speed set' state, the ECM generates a cruise fault. Currently this
results in a frightening 'Controls failed' message on the Eon.

This pull request adds a new controlsd event RESET_V_CRUISE
which allows the gm interface to keep controlsd in sync with the GM ECM.
On 'main on' presses, the gm interface triggers a reset of v_cruise_kph
back to 0. On pressing 'Resume' the GM interface now also checks to make
sure that v_cruise_kph has been set before sending a ENABLE event on Resume
presses.