### PR TITLE
Battery Management and CAMERA_OFFSET fix

### DIFF
--- a/launch_chffrplus.sh
+++ b/launch_chffrplus.sh
@@ -191,7 +191,7 @@ function launch {
 
   # start manager
   cd selfdrive
-  ./manager.py > log.txt
+  ./manager.py
 
   # if broken, keep on screen error
   while true; do sleep 1; done

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -22,6 +22,7 @@ from selfdrive.controls.lib.vehicle_model import VehicleModel
 from selfdrive.controls.lib.longitudinal_planner import LON_MPC_STEP
 from selfdrive.locationd.calibrationd import Calibration
 from selfdrive.hardware import HARDWARE, TICI
+from selfdrive.kegman_conf import kegman_conf
 
 LDW_MIN_SPEED = 31 * CV.MPH_TO_MS
 LANE_DEPARTURE_THRESHOLD = 0.1
@@ -45,6 +46,8 @@ EventName = car.CarEvent.EventName
 class Controls:
   def __init__(self, sm=None, pm=None, can_sock=None):
     config_realtime_process(3, Priority.CTRL_HIGH)
+    self.kegman = kegman_conf()
+    self.mpc_frame = 0
 
     # Setup sockets
     self.pm = pm
@@ -452,11 +455,20 @@ class Controls:
                     and not self.active and self.sm['liveCalibration'].calStatus == Calibration.CALIBRATED
 
     meta = self.sm['modelV2'].meta
+    
+    
+    self.mpc_frame += 1
+    if self.mpc_frame % 200 == 0:
+      # live tuning through /data/openpilot/tune.py for camera
+      self.kegman = kegman_conf()
+      self.mpc_frame = 0
+
+    
     if len(meta.desirePrediction) and ldw_allowed:
       l_lane_change_prob = meta.desirePrediction[Desire.laneChangeLeft - 1]
       r_lane_change_prob = meta.desirePrediction[Desire.laneChangeRight - 1]
-      l_lane_close = left_lane_visible and (self.sm['modelV2'].laneLines[1].y[0] > -(1.08 + CAMERA_OFFSET))
-      r_lane_close = right_lane_visible and (self.sm['modelV2'].laneLines[2].y[0] < (1.08 - CAMERA_OFFSET))
+      l_lane_close = left_lane_visible and (self.sm['modelV2'].laneLines[1].y[0] > -(1.08 + float(self.kegman.conf['cameraOffset']))
+      r_lane_close = right_lane_visible and (self.sm['modelV2'].laneLines[2].y[0] < (1.08 - float(self.kegman.conf['cameraOffset']))
 
       CC.hudControl.leftLaneDepart = bool(l_lane_change_prob > LANE_DEPARTURE_THRESHOLD and l_lane_close)
       CC.hudControl.rightLaneDepart = bool(r_lane_change_prob > LANE_DEPARTURE_THRESHOLD and r_lane_close)

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -10,7 +10,7 @@ from selfdrive.config import Conversions as CV
 from selfdrive.swaglog import cloudlog
 from selfdrive.boardd.boardd import can_list_to_can_capnp
 from selfdrive.car.car_helpers import get_car, get_startup_event, get_one_can
-from selfdrive.controls.lib.lane_planner import CAMERA_OFFSET
+#from selfdrive.controls.lib.lane_planner import CAMERA_OFFSET
 from selfdrive.controls.lib.drive_helpers import update_v_cruise, initialize_v_cruise
 from selfdrive.controls.lib.longcontrol import LongControl, STARTING_TARGET_SPEED
 from selfdrive.controls.lib.latcontrol_pid import LatControlPID

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -467,8 +467,8 @@ class Controls:
     if len(meta.desirePrediction) and ldw_allowed:
       l_lane_change_prob = meta.desirePrediction[Desire.laneChangeLeft - 1]
       r_lane_change_prob = meta.desirePrediction[Desire.laneChangeRight - 1]
-      l_lane_close = left_lane_visible and (self.sm['modelV2'].laneLines[1].y[0] > -(1.08 + float(self.kegman.conf['cameraOffset']))
-      r_lane_close = right_lane_visible and (self.sm['modelV2'].laneLines[2].y[0] < (1.08 - float(self.kegman.conf['cameraOffset']))
+      l_lane_close = left_lane_visible and (self.sm['modelV2'].laneLines[1].y[0] > -(1.08 + float(self.kegman.conf['cameraOffset'])))
+      r_lane_close = right_lane_visible and (self.sm['modelV2'].laneLines[2].y[0] < (1.08 - float(self.kegman.conf['cameraOffset'])))
 
       CC.hudControl.leftLaneDepart = bool(l_lane_change_prob > LANE_DEPARTURE_THRESHOLD and l_lane_close)
       CC.hudControl.rightLaneDepart = bool(r_lane_change_prob > LANE_DEPARTURE_THRESHOLD and r_lane_close)

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -68,7 +68,7 @@ class LanePlanner:
       self.path_offset = float(self.kegman.conf['cameraOffset'])
       self.mpc_frame = 0
 
-    path_xyz[:,1] -= PATH_OFFSET
+    path_xyz[:,1] -= self.path_offset
     l_prob, r_prob = self.lll_prob, self.rll_prob
     width_pts = self.rll_y - self.lll_y
     prob_mods = []

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -4,8 +4,6 @@ from selfdrive.kegman_conf import kegman_conf
 from cereal import log
 
 kegman = kegman_conf()
-PATH_OFFSET = float(kegman.conf['cameraOffset'])  # m from center car to camera
-CAMERA_OFFSET = 0.06
 
 #zorrobyte
 def mean(numbers): 
@@ -47,8 +45,15 @@ class LanePlanner:
       # left and right ll x is the same
       self.ll_x = md.laneLines[1].x
       # only offset left and right lane lines; offsetting path does not make sense
-      self.lll_y = np.array(md.laneLines[1].y) - CAMERA_OFFSET
-      self.rll_y = np.array(md.laneLines[2].y) - CAMERA_OFFSET
+      
+      self.mpc_frame += 1
+      if self.mpc_frame % 200 == 0:
+        # live tuning through /data/openpilot/tune.py for camera
+        self.kegman = kegman_conf()
+        self.mpc_frame = 0
+
+      self.lll_y = np.array(md.laneLines[1].y) - float(self.kegman.conf['cameraOffset'])
+      self.rll_y = np.array(md.laneLines[2].y) - float(self.kegman.conf['cameraOffset'])
       self.lll_prob = md.laneLineProbs[1]
       self.rll_prob = md.laneLineProbs[2]
       self.lll_std = md.laneLineStds[1]
@@ -61,13 +66,7 @@ class LanePlanner:
   def get_d_path(self, v_ego, path_t, path_xyz):
     # Reduce reliance on lanelines that are too far apart or
     # will be in a few seconds
-    self.mpc_frame += 1
-    if self.mpc_frame % 200 == 0:
-      # live tuning through /data/openpilot/tune.py for laneless toggle
-      self.kegman = kegman_conf()
-      self.mpc_frame = 0
 
-    path_xyz[:,1] -= float(self.kegman.conf['cameraOffset'])
     l_prob, r_prob = self.lll_prob, self.rll_prob
     width_pts = self.rll_y - self.lll_y
     prob_mods = []

--- a/selfdrive/controls/lib/lane_planner.py
+++ b/selfdrive/controls/lib/lane_planner.py
@@ -65,10 +65,9 @@ class LanePlanner:
     if self.mpc_frame % 200 == 0:
       # live tuning through /data/openpilot/tune.py for laneless toggle
       self.kegman = kegman_conf()
-      self.path_offset = float(self.kegman.conf['cameraOffset'])
       self.mpc_frame = 0
 
-    path_xyz[:,1] -= self.path_offset
+    path_xyz[:,1] -= float(self.kegman.conf['cameraOffset'])
     l_prob, r_prob = self.lll_prob, self.rll_prob
     width_pts = self.rll_y - self.lll_y
     prob_mods = []

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -20,6 +20,8 @@ from selfdrive.pandad import get_expected_signature
 from selfdrive.swaglog import cloudlog
 from selfdrive.thermald.power_monitoring import PowerMonitoring
 from selfdrive.version import get_git_branch, terms_version, training_version
+from selfdrive.kegman_conf import kegman_conf
+kegman = kegman_conf()
 
 FW_SIGNATURE = get_expected_signature()
 
@@ -147,13 +149,13 @@ def check_car_battery_voltage(should_start, pandaState, charging_disabled, msg):
   #   - onroad isn't started
   print(pandaState)
   
-  if charging_disabled and (pandaState is None or pandaState.pandaState.voltage > 12500 and msg.deviceState.batteryPercent < 40):
+  if charging_disabled and (pandaState is None or pandaState.pandaState.voltage > (int(kegman.conf['carVoltageMinEonShutdown'])+500)) and msg.deviceState.batteryPercent < int(kegman.conf['battChargeMin'])):
     charging_disabled = False
     os.system('echo "1" > /sys/class/power_supply/battery/charging_enabled')
-  elif not charging_disabled and (msg.deviceState.batteryPercent > 80 or (pandaState is not None and pandaState.pandaState.voltage < 11800 and not should_start)):
+  elif not charging_disabled and (msg.deviceState.batteryPercent > int(kegman.conf['battChargeMax']) or (pandaState is not None and pandaState.pandaState.voltage < int(kegman.conf['carVoltageMinEonShutdown']) and not should_start)):
     charging_disabled = True
     os.system('echo "0" > /sys/class/power_supply/battery/charging_enabled')
-  elif msg.deviceState.batteryCurrent < 0 and msg.deviceState.batteryPercent > 80:
+  elif msg.deviceState.batteryCurrent < 0 and msg.deviceState.batteryPercent > int(kegman.conf['battChargeMax']):
     charging_disabled = True
     os.system('echo "0" > /sys/class/power_supply/battery/charging_enabled')
 

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -149,7 +149,7 @@ def check_car_battery_voltage(should_start, pandaState, charging_disabled, msg):
   #   - onroad isn't started
   print(pandaState)
   
-  if charging_disabled and (pandaState is None or pandaState.pandaState.voltage > (int(kegman.conf['carVoltageMinEonShutdown'])+500) and msg.deviceState.batteryPercent < int(kegman.conf['battChargeMin'])):
+  if charging_disabled and (pandaState is None or pandaState.pandaState.voltage > (int(kegman.conf['carVoltageMinEonShutdown'])+500)) and msg.deviceState.batteryPercent < int(kegman.conf['battChargeMin']):
     charging_disabled = False
     os.system('echo "1" > /sys/class/power_supply/battery/charging_enabled')
   elif not charging_disabled and (msg.deviceState.batteryPercent > int(kegman.conf['battChargeMax']) or (pandaState is not None and pandaState.pandaState.voltage < int(kegman.conf['carVoltageMinEonShutdown']) and not should_start)):

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -149,7 +149,7 @@ def check_car_battery_voltage(should_start, pandaState, charging_disabled, msg):
   #   - onroad isn't started
   print(pandaState)
   
-  if charging_disabled and (pandaState is None or pandaState.pandaState.voltage > (int(kegman.conf['carVoltageMinEonShutdown'])+500)) and msg.deviceState.batteryPercent < int(kegman.conf['battChargeMin'])):
+  if charging_disabled and (pandaState is None or pandaState.pandaState.voltage > (int(kegman.conf['carVoltageMinEonShutdown'])+500) and msg.deviceState.batteryPercent < int(kegman.conf['battChargeMin'])):
     charging_disabled = False
     os.system('echo "1" > /sys/class/power_supply/battery/charging_enabled')
   elif not charging_disabled and (msg.deviceState.batteryPercent > int(kegman.conf['battChargeMax']) or (pandaState is not None and pandaState.pandaState.voltage < int(kegman.conf['carVoltageMinEonShutdown']) and not should_start)):

--- a/selfdrive/thermald/thermald.py
+++ b/selfdrive/thermald/thermald.py
@@ -139,6 +139,25 @@ def handle_fan_uno(max_cpu_temp, bat_temp, fan_speed, ignition):
 
   return new_speed
 
+def check_car_battery_voltage(should_start, health, charging_disabled, msg):
+
+  # charging disallowed if:
+  #   - there are health packets from panda, and;
+  #   - 12V battery voltage is too low, and;
+  #   - onroad isn't started
+  print(health)
+  
+  if charging_disabled and (health is None or health.health.voltage > 12500 and msg.thermal.batteryPercent < 40):
+    charging_disabled = False
+    os.system('echo "1" > /sys/class/power_supply/battery/charging_enabled')
+  elif not charging_disabled and (msg.thermal.batteryPercent > 80 or (health is not None and health.health.voltage < 11800 and not should_start)):
+    charging_disabled = True
+    os.system('echo "0" > /sys/class/power_supply/battery/charging_enabled')
+  elif msg.thermal.batteryCurrent < 0 and msg.thermal.batteryPercent > 80:
+    charging_disabled = True
+    os.system('echo "0" > /sys/class/power_supply/battery/charging_enabled')
+
+  return charging_disabled
 
 def set_offroad_alert_if_changed(offroad_alert: str, show_alert: bool, extra_text: Optional[str]=None):
   if prev_offroad_states.get(offroad_alert, None) == (show_alert, extra_text):
@@ -176,6 +195,7 @@ def thermald_thread():
   current_filter = FirstOrderFilter(0., CURRENT_TAU, DT_TRML)
   cpu_temp_filter = FirstOrderFilter(0., CPU_TEMP_TAU, DT_TRML)
   pandaState_prev = None
+  charging_disabled = False
   should_start_prev = False
   handle_fan = None
   is_uno = False
@@ -367,6 +387,15 @@ def thermald_thread():
       if off_ts is None:
         off_ts = sec_since_boot()
 
+    charging_disabled = check_car_battery_voltage(should_start, health, charging_disabled, msg)
+
+    if msg.thermal.batteryCurrent > 0:
+      msg.thermal.batteryStatus = "Discharging"
+    else:
+      msg.thermal.batteryStatus = "Charging"
+
+    
+    msg.thermal.chargingDisabled = charging_disabled
     # Offroad power monitoring
     power_monitor.calculate(pandaState)
     msg.deviceState.offroadPowerUsageUwh = power_monitor.get_power_used()
@@ -389,6 +418,7 @@ def thermald_thread():
     msg.deviceState.thermalStatus = thermal_status
     pm.send("deviceState", msg)
 
+    print(msg)
     set_offroad_alert_if_changed("Offroad_ChargeDisabled", (not usb_power))
 
     should_start_prev = should_start


### PR DESCRIPTION
Re-introduces battery management, honoring kegman.json BattMin / Max values for keeping charge level around the optimum 50-60% level for battery longevity.  I'm on my 3rd year with my OG Eon and it's still on the original battery and it's still like brand new thanks to charge cycling.  Additionally - this is the real camera-offset fix.  there was code in controlsd.py that referenced CAMERA_OFFSET in lane_planner.py.  I've made it a live-tunable parameter in /tune.sh so you can center your car live using the live tuner.