### PR TITLE
Volt: Perfect lateral and 98% perfect longitudinal

### DIFF
--- a/cereal/car.capnp
+++ b/cereal/car.capnp
@@ -441,7 +441,9 @@ struct CarParams {
     kpV @1 :List(Float32);
     kiBP @2 :List(Float32);
     kiV @3 :List(Float32);
-    kf @4 :Float32;
+    kdBP @4 :List(Float32) = [0.];
+    kdV @5 :List(Float32) = [0.];
+    kf @6 :Float32;
   }
 
   struct LongitudinalPIDTuning {
@@ -449,8 +451,11 @@ struct CarParams {
     kpV @1 :List(Float32);
     kiBP @2 :List(Float32);
     kiV @3 :List(Float32);
-    deadzoneBP @4 :List(Float32);
-    deadzoneV @5 :List(Float32);
+    kdBP @4 :List(Float32) = [0.];
+    kdV @5 :List(Float32) = [0.];
+    kf @8 :Float32;
+    deadzoneBP @6 :List(Float32);
+    deadzoneV @7 :List(Float32);
   }
 
   struct LateralINDITuning {

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -47,6 +47,16 @@ class CarInterfaceBase():
   @staticmethod
   def get_params(candidate, fingerprint=gen_empty_fingerprint(), has_relay=False, car_fw=None):
     raise NotImplementedError
+  
+  @staticmethod
+  def get_steer_feedforward_default(desired_angle, v_ego):
+    # Proportional to realigning tire momentum: lateral acceleration.
+    # TODO: something with lateralPlan.curvatureRates
+    return desired_angle * (v_ego**2)
+
+  @staticmethod
+  def get_steer_feedforward_function():
+    return CarInterfaceBase.get_steer_feedforward_default
 
   # returns a set of default params to avoid repetition in car specific params
   @staticmethod

--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -111,7 +111,7 @@ class Controls:
     self.VM = VehicleModel(self.CP)
 
     if self.CP.lateralTuning.which() == 'pid':
-      self.LaC = LatControlPID(self.CP)
+      self.LaC = LatControlPID(self.CP, self.CI)
     elif self.CP.lateralTuning.which() == 'indi':
       self.LaC = LatControlINDI(self.CP)
     elif self.CP.lateralTuning.which() == 'lqr':

--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -1,5 +1,6 @@
 from selfdrive.controls.lib.pid import PIDController
 from selfdrive.controls.lib.drive_helpers import get_steer_max
+from selfdrive.config import Conversions as CV
 from cereal import car
 from cereal import log
 from selfdrive.kegman_conf import kegman_conf
@@ -62,6 +63,14 @@ class LatControlPID():
       self.pid.neg_limit = -steers_max
       
       steer_feedforward = self.get_steer_feedforward(self.angle_steers_des, CS.vEgo)
+      
+      # torque for steer rate. ~0 angle, steer rate ~= steer command.
+      steer_rate_actual = CS.steeringRateDeg
+      steer_rate_desired = lat_plan.lat_plan.steeringAngleDeg
+      speed_mph =  CS.vEgo * CV.MS_TO_MPH
+      steer_rate_max = 0.0389837 * speed_mph**2 - 5.34858 * speed_mph + 223.831
+
+      steer_feedforward += ((steer_rate_desired - steer_rate_actual) / steer_rate_max)
       
       deadzone = self.deadzone    
         

--- a/selfdrive/controls/lib/longcontrol.py
+++ b/selfdrive/controls/lib/longcontrol.py
@@ -1,7 +1,7 @@
 from cereal import log
 from common.numpy_fast import clip, interp
 from common.params import Params
-from selfdrive.controls.lib.pid import PIController
+from selfdrive.controls.lib.pid import PIDController
 from selfdrive.kegman_conf import kegman_conf
 
 kegman = kegman_conf()
@@ -59,7 +59,7 @@ def long_control_state_trans(active, long_control_state, v_ego, v_target, v_pid,
 class LongControl():
   def __init__(self, CP, compute_gb):
     self.long_control_state = LongCtrlState.off  # initialized to off
-    self.pid = PIController((CP.longitudinalTuning.kpBP, CP.longitudinalTuning.kpV),
+    self.pid = PIDController((CP.longitudinalTuning.kpBP, CP.longitudinalTuning.kpV),
                             (CP.longitudinalTuning.kiBP, CP.longitudinalTuning.kiV),
                             rate=RATE,
                             sat_limit=0.8,

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -21,6 +21,9 @@ class kegman_conf():
       if self.conf['Ki'] == "-1":
         self.conf['Ki'] = str(round(CP.lateralTuning.pid.kiV[0],3))
         write_conf = True
+      if self.conf.get('Kd',"-1") == "-1":
+        self.conf['Kd'] = str(round(CP.lateralTuning.pid.kdV[0],3))
+        write_conf = True
       if self.conf['Kf'] == "-1":
         self.conf['Kf'] = str('{:f}'.format(CP.lateralTuning.pid.kf))
         write_conf = True
@@ -53,6 +56,7 @@ class kegman_conf():
         self.config.update({"tuneGernby":"1"})
         self.config.update({"Kp":"-1"})
         self.config.update({"Ki":"-1"})
+        self.config.update({"Kd":"-1"})
         self.element_updated = True
 
       if "liveParams" not in self.config:
@@ -150,7 +154,7 @@ class kegman_conf():
       self.config = {"cameraOffset":"0.06", "lastTrMode":"1", "battChargeMin":"60", "battChargeMax":"70", \
                      "wheelTouchSeconds":"180", "accelerationMode":"1","battPercOff":"25", "carVoltageMinEonShutdown":"11800", \
                      "brakeStoppingTarget":"0.25", "tuneGernby":"1", "AutoHold":"0",\
-                     "Kp":"-1", "Ki":"-1", "liveParams":"1", "leadDistance":"5", "deadzone":"0.0", \
+                     "Kp":"-1", "Ki":"-1", "Kd":"-1", "liveParams":"1", "leadDistance":"5", "deadzone":"0.0", \
                      "1barBP0":"-0.1", "1barBP1":"2.25", "2barBP0":"-0.1", "2barBP1":"2.5", "3barBP0":"0.0", \
                      "3barBP1":"3.0", "1barMax":"2.1", "2barMax":"2.1", "3barMax":"2.1", \
                      "1barHwy":"0.4", "2barHwy":"0.3", "3barHwy":"0.1", \


### PR DESCRIPTION
Replaces stock feedforward with qadmus' sigmoidal feedforward function (fit from log data)  https://github.com/commaai/openpilot/commit/2e0bc9d3653defb51e229d45e0c68447c51785a4, and puts D back in the PID controller, with very, very good Volt lateral and longitudinal tunes.

Martin.R is running this with kegman-ultimate on his very old setup and confirms it's essentially perfect. 

The Volt tunes are speed-dependent, something assumed to not be the case by the kegman.conf stuff, so I disabled live PID tuning for Volt (and any car with custom feedforward; only Volt).

Otherwise, I updated kegman.conf to include kd in a way that doesn't break existing kegman.conf files. 

I expect other cars can benefit greatly from including kd in their lateral tunes to decrease oscillations and enable a significantly higher value of ki to better center the car against persistent lateral forces like road roll or crosswinds, and a somewhat higher value of kp to more assertively change lanes against any potential lateral forces, and better enter/exit curves.